### PR TITLE
Revamp parser function and unify returns

### DIFF
--- a/src/config/parser.js
+++ b/src/config/parser.js
@@ -4,11 +4,16 @@
  * Verdict dictionary.
  * Parser will use this to filter verdict
  * If not matching, by default, parser will use raw verdict
+ * Below is logic bits explanation
+ * 1st      is runnable ?
+ * 2nd      is run in time ?
+ * 3rd      is output correct ?
  */
 module.exports = {
-    "Kết quả khớp đáp án!": "AC",
-    "Kết quả KHÁC đáp án!": "WA",
-    "Chạy quá thời gian": "TLE",
-    "Chạy sinh lỗi": "RTE",
-    default: "RTE"
+    "Kết quả đúng!": 0b111,
+    "Kết quả khớp đáp án!": 0b111,
+    "Kết quả KHÁC đáp án!": 0b110,
+    "Chạy quá thời gian": 0b100,
+    "Chạy sinh lỗi": 0b000,
+    default: 0b000
 };

--- a/src/config/parser.js
+++ b/src/config/parser.js
@@ -9,5 +9,6 @@ module.exports = {
     "Kết quả khớp đáp án!": "AC",
     "Kết quả KHÁC đáp án!": "WA",
     "Chạy quá thời gian": "TLE",
-    "Chạy sinh lỗi": "RTE"
+    "Chạy sinh lỗi": "RTE",
+    default: "RTE"
 };

--- a/src/util/parser.js
+++ b/src/util/parser.js
@@ -5,7 +5,7 @@ const esr = require("escape-string-regexp");
 const { basename, extname } = require("path");
 const { promisify } = require("util");
 
-const verdicts = require("../config/parser");
+const verdictDict = require("../config/parser");
 
 /**
  * Call this to check if given filePath is a File in filesystem
@@ -67,49 +67,65 @@ function logName2Data(filename) {
 const EOL = "\r\n";
 
 /**
+ * @typedef {Object} testDetails
+ * @property {String} time Test case verdict
+ * @property {String} verdict Test verdict
+ * @property {String} msg Extra message from Themis and compiler
+ */
+
+/**
  * Call this function to seperate time and test.
  * The function was refactored from parseTestCase,
  * in order to keep the code clean.
+ * Here's the structure of the Details part in Themis's Log
+ *
+ * - Time (Optional)
+ * - Verdict
+ * - Compiler message (Mostly exit code)
+ *
  * @param {Array} details Test's details line
  */
 function filterDetails(details) {
+    let time = null;
+
+    // Check if there's line with running time
     const rTime = /^Thời gian ≈ (.+) giây/;
-    let time = 0;
     if (rTime.test(details[0])) {
         let timeStr = rTime.exec(details[0]);
         time = Number(timeStr[1]);
         details.shift();
     }
-    const { verdict, msg } = parseTestVerdict(details);
+
+    // Put all other details into msg (Good for debugging)
+
+    // Anonymize exit code
+    // This won't intervene data comes from Themis
+    // If there's problem with ouput, it should be from Themis
+    let exitCode = 0;
+    let hexStr = "00000000";
+    const rExitCode = new RegExp(
+        "exit code: (.+) " + esr("(Hexadecimal: ") + "(.+)" + esr(")")
+    );
+    if (rExitCode.test(details[details.length - 1])) {
+        const lastItem = details.pop();
+        let filterRes = rExitCode.exec(lastItem);
+        exitCode = Number(filterRes[1]);
+        hexStr = filterRes[2].padStart(8, "0");
+    }
+
+    const msg = details
+        .concat(`Process exited with code: ${exitCode} (0x${hexStr})`)
+        .join(EOL);
+
+    // Filter Verdict
+    const verdict =
+        verdictDict[details[details.length - 1]] || verdictDict["default"];
+
     return { time, verdict, msg };
 }
 
 /**
- * @typedef {Object} parsedTestVerdict
- * @property {String} verdict Final test case verdict
- * @property {String} details Further details from test case
- */
-
-/**
- * Call this function to parse rawDeatails into verdicts and details.
- * Cause exceptional test case contains verdict and details after time and result.
- * @param {Array} rawDetails raw extraction from test case in log file
- * @returns {parsedTestVerdict} Verdicts and details from a test case
- */
-function parseTestVerdict(rawDetails) {
-    // Filter Exit code
-    const rExitCode = new RegExp(esr("(Hexadecimal: ") + "(.+)" + esr(")"));
-
-    const verdict = verdicts[rawDetails[0]] || rawDetails[0];
-    const msg = rExitCode.test(rawDetails[1])
-        ? "Exit code: " + rawDetails[1].match(rExitCode)[1]
-        : rawDetails[1] || undefined;
-
-    return { verdict, msg };
-}
-
-/**
- * @typedef {Object} parsedTestCase
+ * @typedef {Object} testCase
  * @property {String} score Final testCase score
  * @property {String} time testCase time
  * @property {String} verdict Final testCase verdict
@@ -121,7 +137,7 @@ function parseTestVerdict(rawDetails) {
  * The whole log file is divided into testCases, and parseTestCase is used
  * in order to retrieve acutal result from Themis.
  * @param {Array} rawTestCase raw extraction of testCase from log file
- * @returns {parsedTestCase} Parsed test case from rawTestCase
+ * @returns {testCase} Parsed test case from rawTestCase
  */
 function parseTestCase(rawTestCase) {
     let [score, ...details] = rawTestCase;
@@ -136,10 +152,9 @@ function parseTestCase(rawTestCase) {
 /**
  * @typedef {Object} submissionResult
  * @property {String} id Submitter's ID
- * @property {String} problem Submission's problem
  * @property {Number} finalScore Submission's final score
- * @property {String} [details] Compiling error
- * @property {Array<parsedTestCase>} [tests] Compilation of testCases result
+ * @property {String} msg Compiling error
+ * @property {Array<testCase>} tests Compilation of testCases result
  */
 
 /**
@@ -162,44 +177,49 @@ async function parseLog(filePath) {
  * @param {String} data log data
  * @param {String} id submission id
  * @param {String} problem problem id
+ * @returns {submissionResult}
  */
 function parseLogData(data, id, problem) {
+    let tests = [];
+
     const lines = data.split(EOL);
 
     const header = esr(`${id}‣${problem}`);
     const rVerdict = new RegExp(header + ": (.*)", "i");
     const rScore = new RegExp(header + "‣.+?: (.*)", "i");
+    const compileStatus = ["Dịch lỗi!", "Dịch thành công."];
+
+    const border = lines.findIndex((s) => compileStatus.indexOf(s) > -1);
 
     const findVerdict = lines[0].match(rVerdict);
-    const totalScore = Number(findVerdict[1]);
+    let totalScore = Number(findVerdict[1]);
+    const msg = lines.slice(3, border).join(EOL);
 
     // CE (Compiler Error) case
-    if (isNaN(totalScore))
-        return {
-            id,
-            totalScore,
-            msg: lines.slice(3).join(EOL)
-        };
+    if (lines[border] === compileStatus[0]) {
+        totalScore = null;
+    } else {
+        const rawTest = lines.slice(border + 2);
+        // Convert log into array of testSuite, additionally with score
+        const rawTestSuite = rawTest.reduce((chunks, line) => {
+            if (rScore.test(line)) {
+                // Get score
+                chunks.push([rScore.exec(line)[1]]);
+            } else {
+                // Get other details
+                chunks[chunks.length - 1].push(line);
+            }
+            return chunks;
+        }, []);
 
-    const rawTest = lines.slice(lines.findIndex((s) => s === "") + 1);
-    // Convert log into array of testSuite, additionally with score
-    const rawTestSuite = rawTest.reduce((chunks, line) => {
-        if (rScore.test(line)) {
-            // Get score
-            chunks.push([rScore.exec(line)[1]]);
-        } else {
-            // Get other details
-            chunks[chunks.length - 1].push(line);
-        }
-        return chunks;
-    }, []);
-
-    const parsedTestSuite = rawTestSuite.map(parseTestCase);
+        tests = rawTestSuite.map(parseTestCase);
+    }
 
     return {
         id,
         totalScore,
-        tests: parsedTestSuite
+        msg,
+        tests
     };
 }
 

--- a/src/util/parser.js
+++ b/src/util/parser.js
@@ -128,7 +128,7 @@ function filterDetails(details) {
  * @typedef {Object} testCase
  * @property {String} score Final testCase score
  * @property {String} time testCase time
- * @property {String} verdict Final testCase verdict
+ * @property {Number} verdict Final testCase verdict
  * @property {String} details Optional testCase details
  */
 


### PR DESCRIPTION
- [x] Unify returns
- [x] Add default case of `verdict`
- [x] Fix the parser so it can read verdict and exit code correctly
- [x] Add more details to `msg`
- [x] Convert verdict to bitmask